### PR TITLE
refactor: Run static analysis only after the whole package was loaded

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,3 +1,8 @@
+---
+hide:
+- navigation
+---
+
 # Examples
 
 ## Simple
@@ -15,6 +20,11 @@
         heading_level: 3
 
 ## Enhanced
+
+> WARNING: **Non-standard features**
+The "enhanced" features are not part of PEP 727.
+They just serve as an example to show what would be possible
+if the PEP was enhanced to account for more use-cases.
 
 /// details | `enhanced` Python module
     type: example

--- a/docs/examples/simple.py
+++ b/docs/examples/simple.py
@@ -41,13 +41,11 @@ def other_parameters(
 
 
 # Documenting yielded and received values, replacing Yields and Receives sections:
-def generator() -> (
-    Generator[
-        Annotated[int, Doc("Yielded integers.")],
-        Annotated[int, Doc("Received integers.")],
-        Annotated[int, Doc("Final returned value.")],
-    ]
-):
+def generator() -> Generator[
+    Annotated[int, Doc("Yielded integers.")],
+    Annotated[int, Doc("Received integers.")],
+    Annotated[int, Doc("Final returned value.")],
+]:
     """Showing off generators."""
 
 
@@ -57,20 +55,18 @@ def iterator() -> Iterator[Annotated[int, Doc("Yielded integers.")]]:
 
 
 # Advanced use-case: documenting multiple yielded/received/returned values:
-def return_tuple() -> (
-    Generator[
-        tuple[
-            Annotated[int, Doc("First element of the yielded value.")],
-            Annotated[float, Doc("Second element of the yielded value.")],
-        ],
-        tuple[
-            Annotated[int, Doc("First element of the received value.")],
-            Annotated[float, Doc("Second element of the received value.")],
-        ],
-        tuple[
-            Annotated[int, Doc("First element of the returned value.")],
-            Annotated[float, Doc("Second element of the returned value.")],
-        ],
-    ]
-):
+def return_tuple() -> Generator[
+    tuple[
+        Annotated[int, Doc("First element of the yielded value.")],
+        Annotated[float, Doc("Second element of the yielded value.")],
+    ],
+    tuple[
+        Annotated[int, Doc("First element of the received value.")],
+        Annotated[float, Doc("Second element of the received value.")],
+    ],
+    tuple[
+        Annotated[int, Doc("First element of the returned value.")],
+        Annotated[float, Doc("Second element of the returned value.")],
+    ],
+]:
     """Showing off tuples as yield/receive/return values."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "griffe>=0.35",
+    "griffe>=0.38",
     "typing-extensions>=4.7",
 ]
 

--- a/src/griffe_typingdoc/_docstrings.py
+++ b/src/griffe_typingdoc/_docstrings.py
@@ -39,7 +39,7 @@ def _to_parameters_section(params_dict: dict[str, dict[str, Any]], func: Functio
                 name=param_name,
                 description=param_doc["description"],
                 annotation=param_doc["annotation"],
-                value=func.parameters[param_name].default,  # type: ignore[arg-type]
+                value=func.parameters[param_name].default,
             )
             for param_name, param_doc in params_dict.items()
         ],

--- a/src/griffe_typingdoc/_docstrings.py
+++ b/src/griffe_typingdoc/_docstrings.py
@@ -39,7 +39,7 @@ def _to_parameters_section(params_dict: dict[str, dict[str, Any]], func: Functio
                 name=param_name,
                 description=param_doc["description"],
                 annotation=param_doc["annotation"],
-                value=func.parameters[param_name].default,
+                value=func.parameters[param_name].default,  # type: ignore[arg-type]
             )
             for param_name, param_doc in params_dict.items()
         ],

--- a/src/griffe_typingdoc/_dynamic.py
+++ b/src/griffe_typingdoc/_dynamic.py
@@ -10,7 +10,16 @@ from griffe_typingdoc._docstrings import _to_parameters_section
 
 if TYPE_CHECKING:
     from griffe import Attribute, Function, ObjectNode
-    from griffe.docstrings.dataclasses import DocstringSectionParameters
+    from griffe.docstrings.dataclasses import (
+        DocstringSectionAdmonition,
+        DocstringSectionOtherParameters,
+        DocstringSectionParameters,
+        DocstringSectionRaises,
+        DocstringSectionReceives,
+        DocstringSectionReturns,
+        DocstringSectionWarns,
+        DocstringSectionYields,
+    )
 
 
 def _hints(node: ObjectNode) -> dict[str, str]:
@@ -29,15 +38,90 @@ def _doc(name: str, hints: dict[str, Any]) -> str | None:
         return None
 
 
-def _attribute_docs(node: ObjectNode, attr: Attribute) -> str:
+def _attribute_docs(attr: Attribute, *, node: ObjectNode, **kwargs: Any) -> str:  # noqa: ARG001
     return _doc(attr.name, _hints(node)) or ""
 
 
-def _parameters_docs(node: ObjectNode, func: Function) -> DocstringSectionParameters | None:
+def _parameters_docs(
+    func: Function,
+    *,
+    node: ObjectNode,
+    **kwargs: Any,  # noqa: ARG001
+) -> DocstringSectionParameters | None:
     hints = _hints(node)
     params_doc: dict[str, dict[str, Any]] = {
         name: {"description": _doc(name, hints)} for name in hints if name != "return"
     }
     if params_doc:
         return _to_parameters_section(params_doc, func)
+    return None
+
+
+# FIXME: Implement this function.
+def _other_parameters_docs(
+    func: Function,  # noqa: ARG001
+    *,
+    node: ObjectNode,  # noqa: ARG001
+    **kwargs: Any,  # noqa: ARG001
+) -> DocstringSectionOtherParameters | None:
+    return None
+
+
+# FIXME: Implement this function.
+def _deprecated_docs(
+    attr_or_func: Attribute | Function,  # noqa: ARG001
+    *,
+    node: ObjectNode,  # noqa: ARG001
+    **kwargs: Any,  # noqa: ARG001
+) -> DocstringSectionAdmonition | None:
+    return None
+
+
+# FIXME: Implement this function.
+def _raises_docs(
+    attr_or_func: Attribute | Function,  # noqa: ARG001
+    *,
+    node: ObjectNode,  # noqa: ARG001
+    **kwargs: Any,  # noqa: ARG001
+) -> DocstringSectionRaises | None:
+    return None
+
+
+# FIXME: Implement this function.
+def _warns_docs(
+    attr_or_func: Attribute | Function,  # noqa: ARG001
+    *,
+    node: ObjectNode,  # noqa: ARG001
+    **kwargs: Any,  # noqa: ARG001
+) -> DocstringSectionWarns | None:
+    return None
+
+
+# FIXME: Implement this function.
+def _yields_docs(
+    func: Function,  # noqa: ARG001
+    *,
+    node: ObjectNode,  # noqa: ARG001
+    **kwargs: Any,  # noqa: ARG001
+) -> DocstringSectionYields | None:
+    return None
+
+
+# FIXME: Implement this function.
+def _receives_docs(
+    func: Function,  # noqa: ARG001
+    *,
+    node: ObjectNode,  # noqa: ARG001
+    **kwargs: Any,  # noqa: ARG001
+) -> DocstringSectionReceives | None:
+    return None
+
+
+# FIXME: Implement this function.
+def _returns_docs(
+    func: Function,  # noqa: ARG001
+    *,
+    node: ObjectNode,  # noqa: ARG001
+    **kwargs: Any,  # noqa: ARG001
+) -> DocstringSectionReturns | None:
     return None

--- a/src/griffe_typingdoc/_extension.py
+++ b/src/griffe_typingdoc/_extension.py
@@ -107,11 +107,11 @@ class TypingDocExtension(Extension):
             return
         if obj.is_module or obj.is_class:
             for member in obj.members.values():
-                self._handle_object(member)
+                self._handle_object(member)  # type: ignore[arg-type]
         elif obj.is_function:
-            self._handle_function(obj)
+            self._handle_function(obj)  # type: ignore[arg-type]
         elif obj.is_attribute:
-            self._handle_attribute(obj)
+            self._handle_attribute(obj)  # type: ignore[arg-type]
 
     def on_package_loaded(
         self,

--- a/src/griffe_typingdoc/_static.py
+++ b/src/griffe_typingdoc/_static.py
@@ -104,7 +104,7 @@ def _attribute_docs(attr: Attribute, **kwargs: Any) -> str:  # noqa: ARG001
 def _parameters_docs(func: Function, **kwargs: Any) -> DocstringSectionParameters | None:  # noqa: ARG001
     params_doc: dict[str, dict[str, Any]] = defaultdict(dict)
     for parameter in _no_self_params(func):
-        stars = {ParameterKind.var_positional: "*", ParameterKind.var_keyword: "**"}.get(parameter.kind, "")
+        stars = {ParameterKind.var_positional: "*", ParameterKind.var_keyword: "**"}.get(parameter.kind, "")  # type: ignore[arg-type]
         param_name = f"{stars}{parameter.name}"
         metadata = _metadata(parameter.annotation)
         description = f'{metadata.get("deprecated", "")} {metadata.get("doc", "")}'.lstrip()
@@ -123,12 +123,12 @@ def _other_parameters_docs(func: Function, **kwargs: Any) -> DocstringSectionPar
                 "typing.Annotated",
                 "typing_extensions.Annotated",
             }:
-                annotation = annotation.slice.elements[0]
+                annotation = annotation.slice.elements[0]  # type: ignore[attr-defined]
             if isinstance(annotation, ExprSubscript) and annotation.canonical_path in {
                 "typing.Unpack",
                 "typing_extensions.Unpack",
             }:
-                typed_dict = annotation.slice.parent.get_member(annotation.slice.name)
+                typed_dict = annotation.slice.parent.get_member(annotation.slice.name)  # type: ignore[attr-defined]
                 params_doc = {
                     attr.name: {"annotation": attr.annotation, "description": _metadata(attr.annotation).get("doc", "")}
                     for attr in typed_dict.members.values()
@@ -147,13 +147,13 @@ def _yields_docs(func: Function, **kwargs: Any) -> DocstringSectionYields | None
 
     if isinstance(annotation, ExprSubscript):
         if annotation.canonical_path in {"typing.Generator", "typing_extensions.Generator"}:
-            yield_annotation = annotation.slice.elements[0]
+            yield_annotation = annotation.slice.elements[0]  # type: ignore[attr-defined]
         elif annotation.canonical_path in {"typing.Iterator", "typing_extensions.Iterator"}:
             yield_annotation = annotation.slice
 
     if yield_annotation:
         if isinstance(yield_annotation, ExprSubscript) and yield_annotation.is_tuple:
-            yield_elements = yield_annotation.slice.elements
+            yield_elements = yield_annotation.slice.elements  # type: ignore[attr-defined]
         else:
             yield_elements = [yield_annotation]
         yields_section = _to_yields_section({"annotation": element, **_metadata(element)} for element in yield_elements)
@@ -171,11 +171,11 @@ def _receives_docs(func: Function, **kwargs: Any) -> DocstringSectionReceives | 
         "typing.Generator",
         "typing_extensions.Generator",
     }:
-        receive_annotation = annotation.slice.elements[1]
+        receive_annotation = annotation.slice.elements[1]  # type: ignore[attr-defined]
 
     if receive_annotation:
         if isinstance(receive_annotation, ExprSubscript) and receive_annotation.is_tuple:
-            receive_elements = receive_annotation.slice.elements
+            receive_elements = receive_annotation.slice.elements  # type: ignore[attr-defined]
         else:
             receive_elements = [receive_annotation]
         receives_section = _to_receives_section(
@@ -195,11 +195,11 @@ def _returns_docs(func: Function, **kwargs: Any) -> DocstringSectionReturns | No
         "typing.Generator",
         "typing_extensions.Generator",
     }:
-        return_annotation = annotation.slice.elements[2]
+        return_annotation = annotation.slice.elements[2]  # type: ignore[attr-defined]
 
     if return_annotation:
         if isinstance(return_annotation, ExprSubscript) and return_annotation.is_tuple:
-            return_elements = return_annotation.slice.elements
+            return_elements = return_annotation.slice.elements  # type: ignore[attr-defined]
         else:
             return_elements = [return_annotation]
         returns_section = _to_returns_section(
@@ -213,7 +213,7 @@ def _warns_docs(attr_or_func: Attribute | Function, **kwargs: Any) -> DocstringS
     if attr_or_func.is_attribute:
         annotation = attr_or_func.annotation
     elif attr_or_func.is_function:
-        annotation = attr_or_func.returns
+        annotation = attr_or_func.returns  # type: ignore[union-attr]
     metadata = _metadata(annotation)
     if metadata["warns"]:
         return _to_warns_section({"annotation": warned[0], "description": warned[1]} for warned in metadata["warns"])
@@ -224,7 +224,7 @@ def _raises_docs(attr_or_func: Attribute | Function, **kwargs: Any) -> Docstring
     if attr_or_func.is_attribute:
         annotation = attr_or_func.annotation
     elif attr_or_func.is_function:
-        annotation = attr_or_func.returns
+        annotation = attr_or_func.returns  # type: ignore[union-attr]
     metadata = _metadata(annotation)
     if metadata["raises"]:
         return _to_raises_section({"annotation": raised[0], "description": raised[1]} for raised in metadata["raises"])
@@ -238,7 +238,7 @@ def _deprecated_docs(
     if attr_or_func.is_attribute:
         annotation = attr_or_func.annotation
     elif attr_or_func.is_function:
-        annotation = attr_or_func.returns
+        annotation = attr_or_func.returns  # type: ignore[union-attr]
     metadata = _metadata(annotation)
     if "deprecated" in metadata:
         return _to_deprecated_section({"description": metadata["deprecated"]})

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -3,15 +3,133 @@
 from griffe.docstrings.dataclasses import DocstringSectionKind
 from griffe.extensions import Extensions
 from griffe.loader import GriffeLoader
+from griffe.tests import temporary_visited_package
 
 from griffe_typingdoc import TypingDocExtension
 
+typing_imports = "from typing import Annotated, Doc, Generator, Iterator, Name, NotRequired, Raises, TypedDict, Unpack, Warns"
+warning_imports = "from warnings import deprecated"
 
-def test_extension() -> None:
+
+def test_extension_on_itself() -> None:
     """Load our own package using the extension, assert a parameters section is added to the parsed docstring."""
     loader = GriffeLoader(extensions=Extensions(TypingDocExtension()))
-    typingdoc = loader.load_module("griffe_typingdoc")
+    typingdoc = loader.load("griffe_typingdoc")
     sections = typingdoc["TypingDocExtension.on_function_instance"].docstring.parsed
     assert len(sections) == 2
     assert sections[1].kind is DocstringSectionKind.parameters
     assert sections[1].value[1].description == "The Griffe function just instantiated."
+
+
+def test_attribute_doc() -> None:
+    """Read documentation for attributes."""
+    with temporary_visited_package(
+        "package",
+        modules={"__init__.py": f"{typing_imports}\na: Annotated[str, Doc('Hello.')]"},
+        extensions=Extensions(TypingDocExtension()),
+    ) as package:
+        assert package["a"].docstring.value == "Hello."
+
+
+def test_parameter_doc() -> None:
+    """Read documentation for parameters."""
+    with temporary_visited_package(
+        "package",
+        modules={"__init__.py": f"{typing_imports}\ndef f(a: Annotated[str, Doc('Hello.')]): ..."},
+        extensions=Extensions(TypingDocExtension()),
+    ) as package:
+        assert package["f"].docstring.parsed[1].value[0].description == "Hello."
+
+
+
+def test_other_parameter_doc() -> None:
+    """Read documentation for other parameters, in unpack/typeddict annotations."""
+    with temporary_visited_package(
+        "package",
+        modules={
+            "__init__.py": f"""
+                {typing_imports}
+                class OtherParameters(TypedDict, total=False):
+                    param1: Annotated[NotRequired[str], Doc("Hello.")]
+
+                def f(**kwargs: Annotated[Unpack[OtherParameters], Doc("See other parameters.")]):
+                    ...
+            """,
+        },
+        extensions=Extensions(TypingDocExtension()),
+    ) as package:
+        assert package["f"].docstring.parsed[2].value[0].description == "Hello."
+
+
+def test_iterator_doc() -> None:
+    """Read documentation in iterator annotations."""
+    with temporary_visited_package(
+        "package",
+        modules={
+            "__init__.py": f"""
+                {typing_imports}
+                def f() -> Iterator[Annotated[int, Doc("Yielded hello.")]]:
+                    ...
+            """,
+        },
+        extensions=Extensions(TypingDocExtension()),
+    ) as package:
+        assert package["f"].docstring.parsed[1].value[0].description == "Yielded hello."
+
+
+def test_generator_doc() -> None:
+    """Read documentation in generator annotations."""
+    with temporary_visited_package(
+        "package",
+        modules={
+            "__init__.py": f"""
+                {typing_imports}
+                def f() -> Generator[
+                    Annotated[int, Doc("Yielded hello.")],
+                    Annotated[int, Doc("Received hello.")],
+                    Annotated[int, Doc("Returned hello.")],
+                ]:
+                    ...
+            """,
+        },
+        extensions=Extensions(TypingDocExtension()),
+    ) as package:
+        sections = package["f"].docstring.parsed
+        assert sections[1].value[0].description == "Yielded hello."
+        assert sections[2].value[0].description == "Received hello."
+        assert sections[3].value[0].description == "Returned hello."
+
+
+def test_generator_tuples() -> None:
+    """Read documentation in generator annotations (in tuples)."""
+    with temporary_visited_package(
+        "package",
+        modules={
+            "__init__.py": f"""
+                {typing_imports}
+                def f() -> Generator[
+                    tuple[
+                        Annotated[int, Doc("First yielded.")],
+                        Annotated[float, Doc("Second yielded.")],
+                    ],
+                    tuple[
+                        Annotated[int, Doc("First received.")],
+                        Annotated[float, Doc("Second received.")],
+                    ],
+                    tuple[
+                        Annotated[int, Doc("First returned.")],
+                        Annotated[float, Doc("Second returned.")],
+                    ],
+                ]:
+                    ...
+            """,
+        },
+        extensions=Extensions(TypingDocExtension()),
+    ) as package:
+        sections = package["f"].docstring.parsed
+        assert sections[1].value[0].description == "First yielded."
+        assert sections[1].value[1].description == "Second yielded."
+        assert sections[2].value[0].description == "First received."
+        assert sections[2].value[1].description == "Second received."
+        assert sections[3].value[0].description == "First returned."
+        assert sections[3].value[1].description == "Second returned."


### PR DESCRIPTION
Closes #7

- We use the new Griffe `on_package_loaded` event to statically analyse things only once the whole package was loaded, to avoid the lookup errors described in #7.
- Code is made more consistent between the static and dynamic helpers (though the dynamic ones still need to be implemented - this can be done later).
- Unit tests added :umbrella: (only for uses described in PEP 727, not the "enhanced" features yet)

@patrick91: I tested on strawberry, and the code duplication workaround isn't needed anymore.
@tiangolo : I checked FastAPI's docs with these changes, all seems good.

Don't hesitate to check for yourselves of course, this would be greatly appreciated :slightly_smiling_face: 
Unless issues are found, I plan to merge and release this tomorrow.